### PR TITLE
make sure the akka containers are restarted

### DIFF
--- a/docker-compose.tmpl.yml
+++ b/docker-compose.tmpl.yml
@@ -215,6 +215,7 @@ services:
 
   fsesl-akka:
     build: mod/fsesl-akka
+    restart: unless-stopped
     depends_on:
       - redis
     environment:
@@ -225,6 +226,7 @@ services:
 
   apps-akka:
     build: mod/apps-akka
+    restart: unless-stopped
     depends_on:
       - redis
     environment:


### PR DESCRIPTION
After host reboot, all services but apps-akka and fsesl-akka come up again, because those didn't have a restart policy.