### PR TITLE
Add git submodule update --init to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Version: 2.3.0 | [Changelog](CHANGELOG.md) | [Issues](https://github.com/bigblue
    ```sh
    $ git clone -b main --recurse-submodules https://github.com/bigbluebutton/docker.git bbb-docker
    $ cd bbb-docker
+   $ git submodule update --init
    ```
 3. Run setup:
    ```bash


### PR DESCRIPTION
Adding `git submodule update --init` to README.md to fix Errors with Building the Container as mentioned in Issue #101