### PR TITLE
Fix for preuploaded presentations not working

### DIFF
--- a/mod/nginx/bbb/greenlight.nginx
+++ b/mod/nginx/bbb/greenlight.nginx
@@ -27,3 +27,8 @@ location /b/cable {
   client_body_timeout 6h;
   send_timeout        6h;
 }
+
+# this is necessary for the preupload_presentation feature
+location /rails/active_storage {
+  return 301 /b$request_uri;
+}


### PR DESCRIPTION
Add a nginx redirect to allow bbb find a pre-uploaded presentation.

ref: https://docs.bigbluebutton.org/greenlight/gl-config.html#updating-from-version-prior-to-27