### PR TITLE
Exclude CLIENT_TITLE when generating compose file

### DIFF
--- a/scripts/generate-compose
+++ b/scripts/generate-compose
@@ -6,8 +6,8 @@ cd $(dirname $0)/..
 # load .env
 if [ -f .env ]
 then
-  # exclude WELCOME_MESSAGE && WELCOME_FOOTER because it may contain invalid characters
-  export $(cat .env | sed 's/#.*//g' | grep -v "WELCOME_FOOTER" | grep -v "WELCOME_MESSAGE" | xargs)
+  # exclude WELCOME_MESSAGE && WELCOME_FOOTER && CLIENT_TITLE because it may contain invalid characters
+  export $(cat .env | sed 's/#.*//g' | grep -v "WELCOME_FOOTER" | grep -v "WELCOME_MESSAGE" | grep -v "CLIENT_TITLE" | xargs)
 fi
 
 # check for non-optional environment variables,


### PR DESCRIPTION
This allows using e.g. dashes in client title.