### PR TITLE
Fix freeswitch package names for languages with uppercase characters in the path

### DIFF
--- a/mod/freeswitch/entrypoint.sh
+++ b/mod/freeswitch/entrypoint.sh
@@ -36,7 +36,7 @@ if [ "$SOUNDS_LANGUAGE" == "de-de-daedalus3" ]; then
 
     fi
 else
-    SOUNDS_PACKAGE=freeswitch-sounds-${SOUNDS_LANGUAGE}
+    SOUNDS_PACKAGE=$(echo "freeswitch-sounds-${SOUNDS_LANGUAGE}" | tr '[:upper:]' '[:lower:]')
     if ! dpkg -s $SOUNDS_PACKAGE >/dev/null 2>&1; then
         echo "sounds package for $SOUNDS_LANGUAGE not installed yet"
         apt-get install $SOUNDS_PACKAGE


### PR DESCRIPTION
Certain [freeswitch sounds](https://github.com/freeswitch/freeswitch-sounds/) have uppercase letters in their path, for example `ru/RU` and `pt/BR`;
This makes it impossible to use them by setting a language in `.env`:

```
SOUNDS_LANGUAGE=ru-RU-elena
```

produces correct directory path:
```
/usr/share/freeswitch/sounds/ru/RU/elena
```

however, it cannot install this package in `entrypoint.sh`, since the package name becomes `freeswitch-sounds-ru-RU-elena` while it has to be lowercase (`freeswitch-sounds-ru-ru-elena`).

This PR fixes this by making package name always lowercase.