### PR TITLE
Reintegrate turn with default ports and support for external certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Version: 2.3.0 | [Changelog](CHANGELOG.md) | [Issues](https://github.com/bigblue
 ## Features
 - Easy installation
 - Greenlight included
+- TURN server included
 - Fully automated HTTPS certificates
 - Full IPv6 support
 - Runs on any major linux distributon (Debian, Ubuntu, CentOS,...)

--- a/docker-compose.tmpl.yml
+++ b/docker-compose.tmpl.yml
@@ -319,6 +319,23 @@ services:
     network_mode: host
 {{end}}
 
+{{ if isTrue .Env.ENABLE_COTURN }}
+  # coturn
+  coturn:
+    image: instrumentisto/coturn:4.5
+    restart: unless-stopped
+    command:
+      - "--external-ip=${EXTERNAL_IPv4}/${EXTERNAL_IPv4}"
+      - "--external-ip=${EXTERNAL_IPv6:-::1}/${EXTERNAL_IPv6:-::1}"
+      - "--static-auth-secret=${TURN_SECRET}"
+    volumes:
+      - ssl_data:/etc/resty-auto-ssl
+      - ./mod/coturn/entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
+      - ./mod/coturn/turnserver.conf:/etc/coturn/turnserver.conf
+    network_mode: host
+{{end}}
+
+
 {{ if isTrue .Env.ENABLE_GREENLIGHT }}
   # greenlight
   greenlight:

--- a/docker-compose.tmpl.yml
+++ b/docker-compose.tmpl.yml
@@ -329,7 +329,12 @@ services:
       - "--external-ip=${EXTERNAL_IPv6:-::1}/${EXTERNAL_IPv6:-::1}"
       - "--static-auth-secret=${TURN_SECRET}"
     volumes:
+      {{ if isTrue .Env.ENABLE_HTTPS_PROXY }}
       - ssl_data:/etc/resty-auto-ssl
+      {{else}}
+      - ${COTURN_TLS_CERT_PATH}:/tmp/cert.pem
+      - ${COTURN_TLS_KEY_PATH}:/tmp/key.pem
+      {{end}}
       - ./mod/coturn/entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
       - ./mod/coturn/turnserver.conf:/etc/coturn/turnserver.conf
     network_mode: host

--- a/docs/development.md
+++ b/docs/development.md
@@ -7,6 +7,7 @@ you can run bbb-docker locally without any certificate issues with following `.e
 DEV_MODE=true
 
 ENABLE_HTTPS_PROXY=true
+#ENABLE_COTURN=true
 #ENABLE_GREENLIGHT=true
 #ENABLE_WEBHOOKS=true
 #ENABLE_PROMETHEUS_EXPORTER=true
@@ -16,7 +17,9 @@ DOMAIN=10.7.7.1
 EXTERNAL_IPv4=10.7.7.1
 STUN_IP=216.93.246.18
 STUN_PORT=3478
+TURN_SERVER=turns:localhost:5349?transport=tcp
 
+TURN_SECRET=SuperTurnSecret
 SHARED_SECRET=SuperSecret
 ETHERPAD_API_KEY=SuperEtherpadKey
 RAILS_SECRET=SuperRailsSecret

--- a/mod/coturn/entrypoint.sh
+++ b/mod/coturn/entrypoint.sh
@@ -1,18 +1,27 @@
 #!/bin/sh
 set -e 
-apk add jq
+if [ "$ENABLE_HTTPS_PROXY" == true ]; then
+  apk add jq
 
-while [ ! -f /etc/resty-auto-ssl/storage/file/*latest ]
-do
-  echo "ERROR: certificate doesn't exist yet."
-  echo "Certificate gets create on the first request to the HTTPS proxy."
-  echo "We will try again..."
-  sleep 10
-done
+  while [ ! -f /etc/resty-auto-ssl/storage/file/*latest ]
+  do
+    echo "ERROR: certificate doesn't exist yet."
+    echo "Certificate gets create on the first request to the HTTPS proxy."
+    echo "We will try again..."
+    sleep 10
+  done
 
-# extract cert
-cat /etc/resty-auto-ssl/storage/file/*%3Alatest | jq -r '.fullchain_pem' > /tmp/cert.pem
-cat /etc/resty-auto-ssl/storage/file/*%3Alatest | jq -r '.privkey_pem' > /tmp/key.pem
+  # extract cert
+  cat /etc/resty-auto-ssl/storage/file/*%3Alatest | jq -r '.fullchain_pem' > /tmp/cert.pem
+  cat /etc/resty-auto-ssl/storage/file/*%3Alatest | jq -r '.privkey_pem' > /tmp/key.pem
+fi
+
+if [ ! -f /tmp/cert.pem ] || [ ! -f /tmp/key.pem ]; then
+  echo "ERROR: certificate not found, but coturn relies on it."
+  echo "Use either auto HTTPS proxy or"
+  echo "provide path to certificates in .env file"
+  exit 1
+fi
 
 # If command starts with an option, prepend with turnserver binary.
 if [ "${1:0:1}" == '-' ]; then

--- a/mod/coturn/entrypoint.sh
+++ b/mod/coturn/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e 
+apk add jq
+
+while [ ! -f /etc/resty-auto-ssl/storage/file/*latest ]
+do
+  echo "ERROR: certificate doesn't exist yet."
+  echo "Certificate gets create on the first request to the HTTPS proxy."
+  echo "We will try again..."
+  sleep 10
+done
+
+# extract cert
+cat /etc/resty-auto-ssl/storage/file/*%3Alatest | jq -r '.fullchain_pem' > /tmp/cert.pem
+cat /etc/resty-auto-ssl/storage/file/*%3Alatest | jq -r '.privkey_pem' > /tmp/key.pem
+
+# If command starts with an option, prepend with turnserver binary.
+if [ "${1:0:1}" == '-' ]; then
+  set -- turnserver "$@"
+fi
+
+exec $(eval "echo $@")

--- a/mod/coturn/turnserver.conf
+++ b/mod/coturn/turnserver.conf
@@ -1,0 +1,73 @@
+# Example coturn configuration for BigBlueButton
+
+# These are the two network ports used by the TURN server which the client
+# may connect to. We enable the standard unencrypted port 3478 for STUN,
+listening-port=3478
+
+# and since TLS over SMTP port (465) is now blocked by major browser vendors, 
+# we reverted to the most common coturn TLS port 5349, which has limitations
+# in restrictive firewall environments. For maximum client support run 
+# coturn on a dedicated host on port 443.
+tls-listening-port=5349
+
+# If the server has multiple IP addresses, you may wish to limit which
+# addresses coturn is using. Do that by setting this option (it can be
+# specified multiple times). The default is to listen on all addresses.
+# You do not normally need to set this option.
+#listening-ip=172.17.19.101
+
+# If the server is behind NAT, you need to specify the external IP address.
+# If there is only one external address, specify it like this:
+#external-ip=172.17.19.120
+# If you have multiple external addresses, you have to specify which
+# internal address each corresponds to, like this. The first address is the
+# external ip, and the second address is the corresponding internal IP.
+#external-ip=172.17.19.131/10.0.0.11
+#external-ip=172.17.18.132/10.0.0.12
+
+# Fingerprints in TURN messages are required for WebRTC
+fingerprint
+
+# The long-term credential mechanism is required for WebRTC
+lt-cred-mech
+
+# Configure coturn to use the "TURN REST API" method for validating time-
+# limited credentials. BigBlueButton will generate credentials in this
+# format. Note that the static-auth-secret value specified here must match
+# the configuration in BigBlueButton's turn-stun-servers.xml
+# You can generate a new random value by running the command:
+#   openssl rand -hex 16
+use-auth-secret
+# static-auth-secret=<random value>
+
+# If the realm value is unspecified, it defaults to the TURN server hostname.
+# You probably want to configure it to a domain name that you control to
+# improve log output. There is no functional impact.
+realm=example.com
+
+# Configure TLS support.
+# Adjust these paths to match the locations of your certificate files
+cert=/tmp/cert.pem
+pkey=/tmp/key.pem
+# Limit the allowed ciphers to improve security
+# Based on https://hynek.me/articles/hardening-your-web-servers-ssl-ciphers/
+cipher-list="ECDH+AESGCM:ECDH+CHACHA20:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:RSA+AESGCM:RSA+AES:!aNULL:!MD5:!DSS"
+
+# Enable longer DH TLS key to improve security
+dh2066
+
+# All WebRTC-compatible web browsers support TLS 1.2 or later, so disable
+# older protocols
+no-tlsv1
+no-tlsv1_1
+
+# To enable single filename logs you need to enable the simple-log flag
+syslog
+#verbose
+
+# Allocate Address Family according 
+# If enabled then TURN server allocates address family according  the TURN 
+# Client <=> Server communication address family.
+# (By default Coturn works according RFC 6156.)
+# !!Warning: Enabling this option breaks RFC6156 section-4.2 (violates use default IPv4)!!
+keep-address-family

--- a/sample.env
+++ b/sample.env
@@ -7,6 +7,10 @@
 # fully automated Lets Encrypt certificates
 ENABLE_HTTPS_PROXY=true
 
+# coturn (a TURN Server)
+# requires HTTPS Proxy to be enabled
+ENABLE_COTURN=true
+
 # Greenlight Frontend
 # https://docs.bigbluebutton.org/greenlight/gl-overview.html
 ENABLE_GREENLIGHT=true

--- a/sample.env
+++ b/sample.env
@@ -8,8 +8,11 @@
 ENABLE_HTTPS_PROXY=true
 
 # coturn (a TURN Server)
-# requires HTTPS Proxy to be enabled
+# requires either the abhove HTTPS Proxy to be enabled 
+# or TLS certificates to be mounted to container
 ENABLE_COTURN=true
+#COTURN_TLS_CERT_PATH=
+#COTURN_TLS_KEY_PATH=
 
 # Greenlight Frontend
 # https://docs.bigbluebutton.org/greenlight/gl-overview.html

--- a/scripts/generate-compose
+++ b/scripts/generate-compose
@@ -19,6 +19,19 @@ if [ -z "$EXTERNAL_IPv4" ]; then
     exit 1
 fi
 
+if [ "$ENABLE_COTURN" == true ]; then
+  if [ -z "$ENABLE_HTTPS_PROXY" ]; then
+    echo "ERROR: coturn requires the https proxy for certificate retrival."
+    echo "you must also set ENABLE_HTTPS_PROXY=true"
+    exit 1
+  fi
+  if [ "$DEV_MODE" == true ]; then
+    echo "ERROR: the https proxy can't get a certificate if ran locally and therefor coturn will never start"
+    echo "you should disable coturn in .env"
+    exit 1
+  fi
+fi
+
 docker run  \
     --rm  \
     -v $(pwd)/docker-compose.tmpl.yml:/docker-compose.tmpl.yml \
@@ -26,6 +39,7 @@ docker run  \
     -e ENABLE_RECORDING=${ENABLE_RECORDING:-false} \
     -e ENABLE_HTTPS_PROXY=${ENABLE_HTTPS_PROXY:-false} \
     -e ENABLE_WEBHOOKS=${ENABLE_WEBHOOKS:-false} \
+    -e ENABLE_COTURN=${ENABLE_COTURN:-false} \
     -e ENABLE_GREENLIGHT=${ENABLE_GREENLIGHT:-false} \
     -e ENABLE_PROMETHEUS_EXPORTER=${ENABLE_PROMETHEUS_EXPORTER:-false} \
     -e NUMBER_OF_BACKEND_NODEJS_PROCESSES=${NUMBER_OF_BACKEND_NODEJS_PROCESSES:-1} \

--- a/scripts/generate-compose
+++ b/scripts/generate-compose
@@ -20,12 +20,13 @@ if [ -z "$EXTERNAL_IPv4" ]; then
 fi
 
 if [ "$ENABLE_COTURN" == true ]; then
-  if [ -z "$ENABLE_HTTPS_PROXY" ]; then
-    echo "ERROR: coturn requires the https proxy for certificate retrival."
-    echo "you must also set ENABLE_HTTPS_PROXY=true"
+  if [ -z "$ENABLE_HTTPS_PROXY" ] && [ -z "$COTURN_TLS_CERT_PATH" ]; then
+    echo "ERROR: coturn requires TLS certificates."
+    echo "Either enable the https proxy for certificate retrival"
+    echo "or provide a path to your certificates in .env file."
     exit 1
   fi
-  if [ "$DEV_MODE" == true ]; then
+  if [ -z "$ENABLE_HTTPS_PROXY" ] && [ "$DEV_MODE" == true ]; then
     echo "ERROR: the https proxy can't get a certificate if ran locally and therefor coturn will never start"
     echo "you should disable coturn in .env"
     exit 1

--- a/scripts/setup
+++ b/scripts/setup
@@ -33,10 +33,20 @@ while [[ ! $https_proxy =~ ^(y|n)$ ]]; do
 done
 
 coturn=""
-if [ "$https_proxy" == "y" ]
+while [[ ! $coturn =~ ^(y|n)$ ]]; do
+    read -p "Should a coturn be included? (y/n): " coturn
+done
+if [ "$coturn" == "y" ] && [ ! "$https_proxy" == "y" ]
 then
-    while [[ ! $coturn =~ ^(y|n)$ ]]; do
-        read -p "Should a coturn be included? (y/n): " coturn
+    echo "Coturn needs TLS to function properly."
+    echo "   Since automatic HTTPS Proxy is disabled,"
+    echo "   you must provide a relative or absolute path"
+    echo "   to your certificates."
+    while [[ -z "$CERTPATH" ]]; do
+        read -p "Please enter path to cert.pem: " CERTPATH 
+    done
+    while [[ -z "$KEYPATH" ]]; do
+        read -p "Please enter path to key.pem: " KEYPATH 
     done
 fi
 
@@ -122,6 +132,12 @@ then
     sed -i "s/.*STUN_IP=.*/STUN_IP=$EXTERNAL_IPv4/" .env
 else
     sed -i "s/ENABLE_COTURN.*/#ENABLE_COTURN=true/" .env
+fi
+
+if [ -n "$CERTPATH" ] && [ -n "$KEYPATH" ]
+then
+    sed -i "s/#COTURN_TLS_CERT_PATH=.*/COTURN_TLS_CERT_PATH=$CERTPATH/" .env
+    sed -i "s/#COTURN_TLS_KEY_PATH=.*/COTURN_TLS_KEY_PATH=$KEYPATH/" .env
 fi
 
 if [ "$prometheus_exporter" == "y" ]

--- a/scripts/setup
+++ b/scripts/setup
@@ -32,6 +32,14 @@ while [[ ! $https_proxy =~ ^(y|n)$ ]]; do
     read -p "Should an automatic HTTPS Proxy be included? (y/n): " https_proxy
 done
 
+coturn=""
+if [ "$https_proxy" == "y" ]
+then
+    while [[ ! $coturn =~ ^(y|n)$ ]]; do
+        read -p "Should a coturn be included? (y/n): " coturn
+    done
+fi
+
 prometheus_exporter=""
 while [[ ! $prometheus_exporter =~ ^(y|n)$ ]]; do
     read -p "Should a Prometheus exporter be included? (y/n): " prometheus_exporter
@@ -104,6 +112,16 @@ fi
 if [ "$recording" == "y" ]
 then
     sed -i "s/#ENABLE_RECORDING.*/ENABLE_RECORDING=true/" .env
+fi
+
+if [ "$coturn" == "y" ]
+then
+    sed -i "s/.*TURN_SERVER=.*/TURN_SERVER=turns:$DOMAIN:5349?transport=tcp/" .env
+    TURN_SECRET=$(head /dev/urandom | tr -dc A-Za-f0-9 | head -c 32)
+    sed -i "s/.*TURN_SECRET=.*/TURN_SECRET=$TURN_SECRET/" .env
+    sed -i "s/.*STUN_IP=.*/STUN_IP=$EXTERNAL_IPv4/" .env
+else
+    sed -i "s/ENABLE_COTURN.*/#ENABLE_COTURN=true/" .env
 fi
 
 if [ "$prometheus_exporter" == "y" ]


### PR DESCRIPTION
It might be reasonable to reintegrate coturn using the default ports (5349) even if this doesn't work for some corporate firewalls. The multiplexing approach for coturn (referenced in #73) was dropped by the jitsi devs. So it seems the current choice is an slightly imperfect coturn setup or none at all.

To allow for more individual setups using a different reverse proxy (nginx, apache), coturn should not depend on the auto HTTPS proxy.