### PR TITLE
updated wget to not use proxies

### DIFF
--- a/docker-compose.tmpl.yml
+++ b/docker-compose.tmpl.yml
@@ -44,7 +44,7 @@ services:
     depends_on:
         - redis
     healthcheck:
-      test: wget --no-verbose --tries=1 --spider http://10.7.7.2:8090/bigbluebutton/api || exit 1
+      test: wget --no-proxy --no-verbose --tries=1 --spider http://10.7.7.2:8090/bigbluebutton/api || exit 1
       start_period: 2m
     environment:
       DEV_MODE: ${DEV_MODE:-}


### PR DESCRIPTION
Unfortunately, docker-compose does not respect noProxy hosts defined in ~/.docker/config.json or /etc/systemd/system/docker.service.d/http-proxy.conf and always uses proxy for healthcheck which causes problems. Resolved this by updating wget to not use proxies when checking for bbb-web health.