### PR TITLE
fixed sed delimiter for CERTPATH and KEYPATH

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -136,8 +136,8 @@ fi
 
 if [ -n "$CERTPATH" ] && [ -n "$KEYPATH" ]
 then
-    sed -i "s/#COTURN_TLS_CERT_PATH=.*/COTURN_TLS_CERT_PATH=$CERTPATH/" .env
-    sed -i "s/#COTURN_TLS_KEY_PATH=.*/COTURN_TLS_KEY_PATH=$KEYPATH/" .env
+    sed -i "s,#COTURN_TLS_CERT_PATH=.*,COTURN_TLS_CERT_PATH=$CERTPATH," .env
+    sed -i "s,#COTURN_TLS_KEY_PATH=.*,COTURN_TLS_KEY_PATH=$KEYPATH," .env
 fi
 
 if [ "$prometheus_exporter" == "y" ]


### PR DESCRIPTION
need to use another delimiter rather than `/` since the $CERTPATH and $KEYPATH variables contain `/` in the full path and cause the following error
```
`sed: -e expression #1, char 50: unknown option to `s'
```

fixes  #137