### PR TITLE
https_proxy: fix setting of ALLOWED_DOMAINS

### DIFF
--- a/docker-compose.tmpl.yml
+++ b/docker-compose.tmpl.yml
@@ -311,10 +311,10 @@ services:
       - ./mod/https/site-ipv4only.conf:/etc/nginx/conf.d/bbb-docker.conf
     {{end}}
     environment:
-      {{ if not .Env.DEV_MODE }}
-      ALLOWED_DOMAINS: ${DOMAIN}
-      {{else}}
+      {{ if isTrue .Env.DEV_MODE }}
       ALLOWED_DOMAINS: ""
+      {{else}}
+      ALLOWED_DOMAINS: ${DOMAIN}
       {{end}}
     network_mode: host
 {{end}}


### PR DESCRIPTION
The template is not correctly checking if DEV_MODE is set to true.
This will always set ALLOWED_DOMAINS to an empty string and allowing to
generate certificates for any domain that points to the application.