### PR TITLE
coturn: expose ENABLE_HTTPS_PROXY env variable

### DIFF
--- a/docker-compose.tmpl.yml
+++ b/docker-compose.tmpl.yml
@@ -337,6 +337,8 @@ services:
       {{end}}
       - ./mod/coturn/entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
       - ./mod/coturn/turnserver.conf:/etc/coturn/turnserver.conf
+    environment:
+      ENABLE_HTTPS_PROXY:
     network_mode: host
 {{end}}
 


### PR DESCRIPTION
The coturn entrypoint checks if ENABLE_HTTPS_PROXY is set but it was not
added the the compose environment stanza so it was never set in the
container.