### PR TITLE
Add missing environment variable to Coturn service

### DIFF
--- a/docker-compose.tmpl.yml
+++ b/docker-compose.tmpl.yml
@@ -115,7 +115,7 @@ services:
       - ./conf/dialplan_public:/etc/freeswitch/dialplan/public_docker
       - vol-freeswitch:/var/freeswitch/meetings
     network_mode: host
-  
+
   nginx:
     build: mod/nginx
     restart: unless-stopped
@@ -156,7 +156,7 @@ services:
       retries: 30
     networks:
       bbb-net:
-        ipv4_address: 10.7.7.5 
+        ipv4_address: 10.7.7.5
 
   mongodb:
     image: mongo:4.4
@@ -177,7 +177,7 @@ services:
   kurento:
     image: kurento/kurento-media-server:6.16
     restart: unless-stopped
-    environment: 
+    environment:
       KMS_STUN_IP: ${STUN_IP}
       KMS_STUN_PORT: ${STUN_PORT}
       KMS_MIN_PORT: 24577
@@ -188,7 +188,7 @@ services:
     network_mode: host
     volumes:
       - vol-kurento:/var/kurento
-  
+
   webrtc-sfu:
     build:  mod/webrtc-sfu
     restart: unless-stopped
@@ -249,7 +249,7 @@ services:
     networks:
       bbb-net:
         ipv4_address: 10.7.7.20
-  
+
   periodic:
     build: mod/periodic
     restart: unless-stopped
@@ -337,6 +337,10 @@ services:
       {{end}}
       - ./mod/coturn/entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
       - ./mod/coturn/turnserver.conf:/etc/coturn/turnserver.conf
+   {{ if isTrue .Env.ENABLE_HTTPS_PROXY }}
+    environment:
+      - ENABLE_HTTPS_PROXY: ${ENABLE_HTTPS_PROXY}
+   {{end}}
     network_mode: host
 {{end}}
 
@@ -383,7 +387,7 @@ services:
   prometheus-exporter:
     image: greenstatic/bigbluebutton-exporter:v0.7.0-preview2
     restart: unless-stopped
-    environment: 
+    environment:
       API_BASE_URL: http://10.7.7.1:8080/bigbluebutton/api/
       API_SECRET: ${SHARED_SECRET}
       RECORDINGS_METRICS_READ_FROM_DISK: "false"


### PR DESCRIPTION
## What 
This pr adds `ENABLE_HTTPS_PROXY` environment variable to the [Coturn service](https://github.com/bigbluebutton/docker/blob/0dd3d9a0bc7ea3169e71f27246702f870a3607db/docker-compose.tmpl.yml#L322-L341). This var is required to be present in the container and will be used in [`/mod/coturn/entrypoint.sh`](https://github.com/bigbluebutton/docker/blob/0dd3d9a0bc7ea3169e71f27246702f870a3607db/mod/coturn/entrypoint.sh#L3) for extracting TLS certificates. This is a boolean var which reflects user decision regarding [enabling an automatic http proxy](https://github.com/bigbluebutton/docker/blob/0dd3d9a0bc7ea3169e71f27246702f870a3607db/scripts/setup#L117-L120).  

#### When var is not available
- Looking at `docker logs` one can read the following error when the var is not present but user wishes to enable an http proxy
```
ERROR: certificate not found, but coturn relies on it.
Use either auto HTTPS proxy or
provide path to certificates in .env file
```
- The `bbb-docker_coturn_1` container restarts for ever
```
5d2d44c70109   instrumentisto/coturn:4.5   "docker-entrypoint.s…"   About a minute ago   Restarting (1) 28 seconds ago                              bbb-docker_coturn_1

```
