### PR TITLE
Automatically remove old recordings after N days

### DIFF
--- a/docker-compose.tmpl.yml
+++ b/docker-compose.tmpl.yml
@@ -115,7 +115,7 @@ services:
       - ./conf/dialplan_public:/etc/freeswitch/dialplan/public_docker
       - vol-freeswitch:/var/freeswitch/meetings
     network_mode: host
-  
+
   nginx:
     build: mod/nginx
     restart: unless-stopped
@@ -156,7 +156,7 @@ services:
       retries: 30
     networks:
       bbb-net:
-        ipv4_address: 10.7.7.5 
+        ipv4_address: 10.7.7.5
 
   mongodb:
     image: mongo:4.4
@@ -177,7 +177,7 @@ services:
   kurento:
     image: kurento/kurento-media-server:6.16
     restart: unless-stopped
-    environment: 
+    environment:
       KMS_STUN_IP: ${STUN_IP}
       KMS_STUN_PORT: ${STUN_PORT}
       KMS_MIN_PORT: 24577
@@ -188,7 +188,7 @@ services:
     network_mode: host
     volumes:
       - vol-kurento:/var/kurento
-  
+
   webrtc-sfu:
     build:  mod/webrtc-sfu
     restart: unless-stopped
@@ -249,7 +249,7 @@ services:
     networks:
       bbb-net:
         ipv4_address: 10.7.7.20
-  
+
   periodic:
     build: mod/periodic
     restart: unless-stopped
@@ -258,6 +258,12 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - bigbluebutton:/var/bigbluebutton
+    tmpfs:
+      - /var/log/bigbluebutton
+    environment:
+      ENABLE_RECORDING: ${ENABLE_RECORDING}
+      REMOVE_OLD_RECORDING: ${REMOVE_OLD_RECORDING}
+      RECORDING_MAX_AGE_DAYS: ${RECORDING_MAX_AGE_DAYS}
     networks:
       bbb-net:
         ipv4_address: 10.7.7.12
@@ -385,7 +391,7 @@ services:
   prometheus-exporter:
     image: greenstatic/bigbluebutton-exporter:v0.7.0-preview2
     restart: unless-stopped
-    environment: 
+    environment:
       API_BASE_URL: http://10.7.7.1:8080/bigbluebutton/api/
       API_SECRET: ${SHARED_SECRET}
       RECORDINGS_METRICS_READ_FROM_DISK: "false"

--- a/mod/periodic/Dockerfile
+++ b/mod/periodic/Dockerfile
@@ -10,6 +10,8 @@ RUN apt-get update \
 # -- install docker cli
 COPY --from=library/docker:latest /usr/local/bin/docker /usr/bin/docker
 
-COPY bbb-restart-kms bbb-resync-freeswitch entrypoint.sh /
+COPY bbb-remove-old-recordings bbb-restart-kms bbb-resync-freeswitch entrypoint.sh /
+
+RUN chmod +x bbb-remove-old-recordings
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/mod/periodic/bbb-remove-old-recordings
+++ b/mod/periodic/bbb-remove-old-recordings
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Source: https://docs.bigbluebutton.org/admin/customize.html#delete-recordings-older-than-n-days
+
+set -e
+LOGFILE=/var/log/bigbluebutton/bbb-recording-cleanup-$(date --iso-8601='seconds' -u).log
+shopt -s nullglob
+NOW=$(date +%s)
+
+echo "$(date --rfc-3339=seconds) Deleting recordings older than ${RECORDING_MAX_AGE_DAYS} days" >"${LOGFILE}"
+
+# Find the name of recordings container in order to access `bbb-record` utility
+BBB_RECORDINGS_CONTAINER_NAME=$(docker ps --filter "name=recordings" --filter "status=running" --format "{{.Names}}")
+if [ $BBB_RECORDINGS_CONTAINER_NAME == "" ]; then
+  echo "$(date --rfc-3339=seconds) ERROR: recordings container is not running" >>"${LOGFILE}"
+  exit 1
+fi
+
+for donefile in /var/bigbluebutton/recording/status/published/*-presentation.done ; do
+        MTIME=$(stat -c %Y "${donefile}")
+        # Check the age of the recording
+        if [ $(( ( $NOW - $MTIME ) / 86400 )) -gt $RECORDING_MAX_AGE_DAYS ]; then
+                MEETING_ID=$(basename "${donefile}")
+                MEETING_ID=${MEETING_ID%-presentation.done}
+                echo "${MEETING_ID}" >> "${LOGFILE}"
+
+                docker exec "$BBB_RECORDINGS_CONTAINER_NAME" bbb-record --delete "${MEETING_ID}" >>"${LOGFILE}"
+        fi
+done
+
+for eventsfile in /var/bigbluebutton/recording/raw/*/events.xml ; do
+        MTIME=$(stat -c %Y "${eventsfile}")
+        # Check the age of the recording
+        if [ $(( ( $NOW - $MTIME ) / 86400 )) -gt $RECORDING_MAX_AGE_DAYS ]; then
+                MEETING_ID="${eventsfile%/events.xml}"
+                MEETING_ID="${MEETING_ID##*/}"
+                echo "${MEETING_ID}" >> "${LOGFILE}"
+
+                docker exec "$BBB_RECORDINGS_CONTAINER_NAME" bbb-record --delete "${MEETING_ID}" >>"${LOGFILE}"
+        fi
+done

--- a/mod/periodic/entrypoint.sh
+++ b/mod/periodic/entrypoint.sh
@@ -9,12 +9,17 @@ while :
 do
 	# restart kurento after 24h
 	/bbb-restart-kms
-	
+
 	# resync freeswitch
 	/bbb-resync-freeswitch
 
 	# delete presentations older than N days
 	find /var/bigbluebutton/ -maxdepth 1 -type d -name "*-*" -mtime +$history -exec rm -rf '{}' +
+
+  # delete recordings older than $RECORDING_MAX_AGE_DAYS
+  if [ "$ENABLE_RECORDING" == true ] && [ "$REMOVE_OLD_RECORDING" == true ]; then
+    /bbb-remove-old-recordings
+  fi
 
 	sleep 30m
 done

--- a/sample.env
+++ b/sample.env
@@ -8,7 +8,7 @@
 ENABLE_HTTPS_PROXY=true
 
 # coturn (a TURN Server)
-# requires either the abhove HTTPS Proxy to be enabled 
+# requires either the abhove HTTPS Proxy to be enabled
 # or TLS certificates to be mounted to container
 ENABLE_COTURN=true
 #COTURN_TLS_CERT_PATH=
@@ -28,12 +28,14 @@ ENABLE_GREENLIGHT=true
 #ENABLE_PROMETHEUS_EXPORTER=true
 
 # Recording
-# IMPORTANT: this is currently a big privacy issues, because it will 
+# IMPORTANT: this is currently a big privacy issues, because it will
 # record everything which happens in the conference, even when the button
 # suggets, that it does not.
 # https://github.com/bigbluebutton/bigbluebutton/issues/9202
 # make sure that you get peoples consent, before they join a room
 #ENABLE_RECORDING=true
+#REMOVE_OLD_RECORDING=false
+#RECORDING_MAX_AGE_DAYS=14
 
 # ====================================
 # SECRETS
@@ -132,7 +134,7 @@ CHAT_START_CLOSED=false
 # set to true to disable announcements "You are now (un-)muted"
 DISABLE_SOUND_MUTED=false
 
-# set to true to disable announcement "You are the only person in this conference" 
+# set to true to disable announcement "You are the only person in this conference"
 DISABLE_SOUND_ALONE=false
 
 # maximum count of breakout rooms per meeting
@@ -224,7 +226,7 @@ ALLOW_GREENLIGHT_ACCOUNTS=true
 #   SMTP_AUTH=plain
 #   SMTP_STARTTLS_AUTO=true
 #
-# If your mail server has a self-signed certificate, you'll also need to include the line below. 
+# If your mail server has a self-signed certificate, you'll also need to include the line below.
 # Please note that enable this presents its own security risks and should not be done unless necessary.
 #   SMTP_OPENSSL_VERIFY_MODE=none
 #

--- a/scripts/generate-compose
+++ b/scripts/generate-compose
@@ -38,6 +38,8 @@ docker run  \
     -v $(pwd)/docker-compose.tmpl.yml:/docker-compose.tmpl.yml \
     -e DEV_MODE=${DEV_MODE:-false} \
     -e ENABLE_RECORDING=${ENABLE_RECORDING:-false} \
+    -e REMOVE_OLD_RECORDING=${REMOVE_OLD_RECORDING:-false} \
+    -e RECORDING_MAX_AGE_DAYS=${RECORDING_MAX_AGE_DAYS:-14} \
     -e ENABLE_HTTPS_PROXY=${ENABLE_HTTPS_PROXY:-false} \
     -e ENABLE_WEBHOOKS=${ENABLE_WEBHOOKS:-false} \
     -e ENABLE_COTURN=${ENABLE_COTURN:-false} \

--- a/scripts/setup
+++ b/scripts/setup
@@ -43,10 +43,10 @@ then
     echo "   you must provide a relative or absolute path"
     echo "   to your certificates."
     while [[ -z "$CERTPATH" ]]; do
-        read -p "Please enter path to cert.pem: " CERTPATH 
+        read -p "Please enter path to cert.pem: " CERTPATH
     done
     while [[ -z "$KEYPATH" ]]; do
-        read -p "Please enter path to key.pem: " KEYPATH 
+        read -p "Please enter path to key.pem: " KEYPATH
     done
 fi
 
@@ -71,6 +71,24 @@ while [[ ! $recording =~ ^(y|n)$ ]]; do
 
     read -p "Choice (y/n): " recording
 done
+
+if [ "$recording" == "y" ]
+then
+
+  remove_old_recording=""
+  while [[ ! $remove_old_recording =~ ^(y|n)$ ]]; do
+      read -p "Should old recordings be removed? (y/n): " remove_old_recording
+  done
+
+  if [ "$remove_old_recording" == "y" ]
+  then
+    recording_max_age_days=""
+    while [[ ! $recording_max_age_days =~ ^[0-9]{1,4}$ ]]; do
+        read -p "Please enter max age(days) for keeping recordings: " recording_max_age_days
+    done
+  fi
+
+fi
 
 ip_correct=""
 while [[ ! $ip_correct =~ ^(y|n)$ ]]; do
@@ -122,6 +140,12 @@ fi
 if [ "$recording" == "y" ]
 then
     sed -i "s/#ENABLE_RECORDING.*/ENABLE_RECORDING=true/" .env
+fi
+
+if [ "$remove_old_recording" == "y" ]
+then
+    sed -i "s/#REMOVE_OLD_RECORDING=.*/REMOVE_OLD_RECORDING=true/" .env
+    sed -i "s/#RECORDING_MAX_AGE_DAYS=.*/RECORDING_MAX_AGE_DAYS=$recording_max_age_days/" .env
 fi
 
 if [ "$coturn" == "y" ]


### PR DESCRIPTION
## What
This pr adds the possbility of cleaning old recordings after N days. The task will be triggered by Periodic service.

## Why
As an admin, I'd like to activate an automatic process for removing old recordings after a configurable amount of time(days).

## How
- During the setup user can enable the feature if they decide to enable the `recoridng` as well.
  -  A boolean env vars named `REMOVE_OLD_RECORDING` for enabling the feature will be set.
  -  An integer env var named `RECORDING_MAX_AGE_DAYS` for setting the max age of recording will be set.
- Official shell script developed by BigBlueButton is used for [removing recordings after N days](https://docs.bigbluebutton.org/admin/customize.html#delete-recordings-older-than-n-days)
- Official recordings utility named [`bbb-record`](https://docs.bigbluebutton.org/dev/recording.html#manage-recordings) which is available in [`recordings` service](https://github.com/bigbluebutton/docker/blob/40db868ccdb53c66cf182006348163f005ee6418/mod/recordings/Dockerfile#L76-L82) is used.