### PR TITLE
Ignore docker-compose.override.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 docker-compose.yml 
+docker-compose.override.yml
 
 # IDEA generated
 .idea


### PR DESCRIPTION
I think, that the `docker-compose.override.yml` should be ignored. Like this, it is possible to make changes to the docker-compose without actually modifying it. I am using this to add some labels to nginx for traefik:
```yml
services:
  nginx:
    labels:
      - "traefik.enable=true"
      - "traefik.http.routers.bbb.entrypoints=web-secure"
      - "traefik.http.routers.bbb.rule=Host(`bbb.example.com`)"
      - "traefik.http.routers.bbb.service=bbb"
      - "traefik.http.services.bbb.loadbalancer.server.port=48087"
```