### PR TITLE
fix for presentation slides not displayed if they contain type 3 fonts

### DIFF
--- a/mod/bbb-web/Dockerfile
+++ b/mod/bbb-web/Dockerfile
@@ -81,7 +81,9 @@ RUN mkdir -p /usr/share/bigbluebutton/blank \
         https://raw.githubusercontent.com/bigbluebutton/bigbluebutton/v2.4.0/bigbluebutton-config/slides/blank-thumb.png \
         https://raw.githubusercontent.com/bigbluebutton/bigbluebutton/v2.4.0/bigbluebutton-config/slides/blank-presentation.pdf \
         https://raw.githubusercontent.com/bigbluebutton/bigbluebutton/v2.4.0/bigbluebutton-config/slides/blank-png.png \
-    && sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="write" pattern="PDF" \/>/g' /etc/ImageMagick-6/policy.xml
+    && sed -i 's/<policy domain="coder" rights="none" pattern="PDF" \/>/<policy domain="coder" rights="write" pattern="PDF" \/>/g' /etc/ImageMagick-6/policy.xml \
+    && sed -i '/potrace/d' /etc/ImageMagick-6/delegates.xml
+
 
 # get bbb-web
 COPY --from=builder /dist /usr/share/bbb-web


### PR DESCRIPTION
This change deletes the potrace rules from imagemagick. Otherwise it tries to use potrace, which is not installed and would create ugly monochrome slides. Without this change, https://github.com/bigbluebutton/bigbluebutton/blob/d8350f813c7611e33f1a61d65e341f7e811a2da1/bbb-common-web/src/main/java/org/bigbluebutton/presentation/imp/SvgImageCreatorImp.java#L223 fails in the docker version of BBB. The users see this effect as blank slides. This path is triggered by type 3 fonts in the page. 

Background: bbb-web tries to avoid pdftocairo for pages with type 3 fonts, see https://gitlab.freedesktop.org/poppler/poppler/-/issues/268
And imagemagick changed its behaviour around version 7.0.8-65, see https://legacy.imagemagick.org/discourse-server/viewtopic.php?t=36777