### PR TITLE
Update Russian sound announcement examples

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -107,9 +107,9 @@ DEFAULT_PRESENTATION=./mod/nginx/default.pdf
 # - es-ar-mario - Spanish/Argentina Mario
 # - fr-ca-june - FR Canadian June
 # - pt-br-karina - Brazilian Portuguese Karina
-# - ru-ru-elena - RU Russian Elena
-# - ru-ru-kirill - RU Russian Kirill
-# - ru-ru-vika - RU Russian Viktoriya
+# - ru-RU-elena - RU Russian Elena
+# - ru-RU-kirill - RU Russian Kirill
+# - ru-RU-vika - RU Russian Viktoriya
 # - sv-se-jakob - Swedish (Sweden) Jakob
 # - zh-cn-sinmei - Chinese/China Sinmei
 # - zh-hk-sinmei - Chinese/Hong Kong Sinmei


### PR DESCRIPTION
Simple tweak that changes example to the actual useful values because lowercase "ru-ru" doesn't repeat directory structure of the freeswitch package.