### PR TITLE
Fix learning-dashboard

### DIFF
--- a/mod/bbb-web/Dockerfile
+++ b/mod/bbb-web/Dockerfile
@@ -101,4 +101,7 @@ COPY turn-stun-servers.xml /usr/share/bbb-web/WEB-INF/classes/spring/turn-stun-s
 COPY logback.xml /usr/share/bbb-web/WEB-INF/classes/logback.xml
 COPY office-convert.sh /usr/share/bbb-libreoffice-conversion/convert.sh
 
+# add symlink /var/bigbluebutton/learning-analytics-dashboard --> /var/bigbluebutton/learning-dashboard
+RUN mkdir -p /var/bigbluebutton/learning-dashboard/ && ln -s /var/bigbluebutton/learning-dashboard/ /var/bigbluebutton/learning-analytics-dashboard
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/mod/nginx/bbb/learning-dashboard.nginx
+++ b/mod/nginx/bbb/learning-dashboard.nginx
@@ -1,5 +1,5 @@
 location ~ /learning-analytics-dashboard/([0-9a-f]+-[0-9]+)/(.*) {
-    root /var/bigbluebutton/learning-analytics-dashboard/;
+    root /var/bigbluebutton/;
     autoindex off;
 }
 


### PR DESCRIPTION
After session ends, clicking on the button "Open Learning-Dashboard" on the screen "This conference has ended" leads to "Data is no longer available"

The problem is the wrong root in the nginx config and because of the naming change from learning-dashboard to learning-analytics-dashboard in version 2.4.4 (2.4.x not affected) the folder does not exist.

We would be happy if it gets fixed, with this solution or another better fix :)