### PR TITLE
chore: update Etherpad

### DIFF
--- a/mod/etherpad/Dockerfile
+++ b/mod/etherpad/Dockerfile
@@ -1,4 +1,4 @@
-FROM etherpad/etherpad:1.8.16
+FROM etherpad/etherpad:1.8.17
 
 USER root
 

--- a/mod/etherpad/Dockerfile
+++ b/mod/etherpad/Dockerfile
@@ -7,11 +7,10 @@ RUN apt-get update \
 
 USER etherpad
 
-# ep_cursortrace: using mconf's fork due to https://github.com/ether/ep_cursortrace/pull/25 not being accepted upstream
 RUN npm install  \
     ep_cursortrace@3.1.12 \
-    git+https://github.com/pedrobmarin/ep_pad_ttl.git#360136cd38493dd698435631f2373cbb7089082d \
-    git+https://github.com/pedrobmarin/ep_redis_publisher.git#1d903bf900dd53ebc5347f9583b6e240cf754d63 \
+    git+https://github.com/mconf/ep_pad_ttl.git#360136cd38493dd698435631f2373cbb7089082d \
+    git+https://github.com/mconf/ep_redis_publisher.git#1d903bf900dd53ebc5347f9583b6e240cf754d63 \
     git+https://github.com/ether/ep_disable_chat.git#v0.0.4 \
 # remove npm lockfile, because somehow it prevents etherpad from detecting the manual added plugin ep_bigbluebutton_patches
     && rm package-lock.json

--- a/mod/etherpad/Dockerfile
+++ b/mod/etherpad/Dockerfile
@@ -13,7 +13,6 @@ RUN npm install  \
     git+https://github.com/pedrobmarin/ep_pad_ttl.git#360136cd38493dd698435631f2373cbb7089082d \
     git+https://github.com/pedrobmarin/ep_redis_publisher.git#1d903bf900dd53ebc5347f9583b6e240cf754d63 \
     git+https://github.com/ether/ep_disable_chat.git#v0.0.4 \
-    git+https://github.com/ether/ep_sticky_attributes.git#v0.1.10 \
 # remove npm lockfile, because somehow it prevents etherpad from detecting the manual added plugin ep_bigbluebutton_patches
     && rm package-lock.json
 

--- a/mod/etherpad/settings.json
+++ b/mod/etherpad/settings.json
@@ -15,6 +15,31 @@
  *
  * This is useful, for example, when running in a Docker container.
  *
+ * DETAILED RULES:
+ *   - If the environment variable is set to the string "true" or "false", the
+ *     value becomes Boolean true or false.
+ *   - If the environment variable is set to the string "null", the value
+ *     becomes null.
+ *   - If the environment variable is set to the string "undefined", the setting
+ *     is removed entirely, except when used as the member of an array in which
+ *     case it becomes null.
+ *   - If the environment variable is set to a string representation of a finite
+ *     number, the string is converted to that number.
+ *   - If the environment variable is set to any other string, including the
+ *     empty string, the value is that string.
+ *   - If the environment variable is unset and a default value is provided, the
+ *     value is as if the environment variable was set to the provided default:
+ *       - "${UNSET_VAR:}" becomes the empty string.
+ *       - "${UNSET_VAR:foo}" becomes the string "foo".
+ *       - "${UNSET_VAR:true}" and "${UNSET_VAR:false}" become true and false.
+ *       - "${UNSET_VAR:null}" becomes null.
+ *       - "${UNSET_VAR:undefined}" causes the setting to be removed (or be set
+ *         to null, if used as a member of an array).
+ *   - If the environment variable is unset and no default value is provided,
+ *     the value becomes null. THIS BEHAVIOR MAY CHANGE IN A FUTURE VERSION OF
+ *     ETHERPAD; if you want the default value to be null, you should explicitly
+ *     specify "null" as the default value.
+ *
  * EXAMPLE:
  *    "port":     "${PORT:9001}"
  *    "minify":   "${MINIFY}"
@@ -56,506 +81,526 @@
  *    "password": "${PASSW}"  // if PASSW is not defined would result in password === null
  *    "password": "${PASSW:}" // if PASSW is not defined would result in password === ''
  *
+ *    If you want to use an empty value (null) as default value for a variable,
+ *    simply do not set it, without putting any colons: "${ABIWORD}".
+ *
+ * 3) if you want to use newlines in the default value of a string parameter,
+ *    use "\n" as usual.
+ *
+ *    "defaultPadText" : "${DEFAULT_PAD_TEXT}Line 1\nLine 2"
  */
- {
-    /*
-     * Name your instance!
-     */
-    "title": "Etherpad",
-  
-    /*
-     * favicon default name
-     * alternatively, set up a fully specified Url to your own favicon
-     */
-    "favicon": "favicon.ico",
-  
-    /*
-     * Skin name.
-     *
-     * Its value has to be an existing directory under src/static/skins.
-     * You can write your own, or use one of the included ones:
-     *
-     * - "no-skin":  an empty skin (default). This yields the unmodified,
-     *               traditional Etherpad theme.
-     * - "colibris": the new experimental skin (since Etherpad 1.8), candidate to
-     *               become the default in Etherpad 2.0
-     */
-    "skinName": "bigbluebutton",
-  
-    /*
-     * IP and port which etherpad should bind at
-     */
-    "ip": "0.0.0.0",
-    "port": 9001,
-  
-    /*
-     * Option to hide/show the settings.json in admin page.
-     *
-     * Default option is set to true
-     */
-    "showSettingsInAdminPage": true,
-  
-    /*
-     * Node native SSL support
-     *
-     * This is disabled by default.
-     * Make sure to have the minimum and correct file access permissions set so
-     * that the Etherpad server can access them
-     */
-  
-    /*
-    "ssl" : {
-              "key"  : "/path-to-your/epl-server.key",
-              "cert" : "/path-to-your/epl-server.crt",
-              "ca": ["/path-to-your/epl-intermediate-cert1.crt", "/path-to-your/epl-intermediate-cert2.crt"]
-            },
-    */
-  
-    /*
-     * The type of the database.
-     *
-     * You can choose between many DB drivers, for example: dirty, postgres,
-     * sqlite, mysql.
-     *
-     * You shouldn't use "dirty" for for anything else than testing or
-     * development.
-     *
-     *
-     * Database specific settings are dependent on dbType, and go in dbSettings.
-     * Remember that since Etherpad 1.6.0 you can also store these informations in
-     * credentials.json.
-     *
-     * For a complete list of the supported drivers, please refer to:
-     * https://www.npmjs.com/package/ueberdb2
-     */
-  
-    "dbType": "redis",
-    "dbSettings": {
-      "host": "redis",
-      "port": 6379
-    },
-  
-    /*
-     * An Example of MySQL Configuration (commented out).
-     *
-     * See: https://github.com/ether/etherpad-lite/wiki/How-to-use-Etherpad-Lite-with-MySQL
-     */
-  
-    /*
-    "dbType" : "mysql",
-    "dbSettings" : {
-      "user":     "etherpaduser",
-      "host":     "localhost",
-      "port":     3306,
-      "password": "PASSWORD",
-      "database": "etherpad_lite_db",
-      "charset":  "utf8mb4"
-    },
-    */
-  
-    /*
-    "dbType" : "redis",
-    "dbSettings" : {
-      "host": "localhost",
-      "port": 6379,
-      "client_options": {
-        "password": "PASSWORD"
-      }
-    },
-    */
-  
-    /*
-     * The default text of a pad
-     */
-    "defaultPadText" : "",
-  
-    /*
-     * Default Pad behavior.
-     *
-     * Change them if you want to override.
-     */
-    "padOptions": {
-      "noColors":         true,
-      "showControls":     true,
-      "showChat":         false,
-      "showLineNumbers":  false,
-      "useMonospaceFont": false,
-      "userName":         false,
-      "userColor":        false,
-      "rtl":              false,
-      "alwaysShowChat":   false,
-      "chatAndUsers":     false,
-      "lang":             "en-gb"
-    },
-  
-    /*
-     * Pad Shortcut Keys
-     */
-    "padShortcutEnabled" : {
-      "altF9":     true, /* focus on the File Menu and/or editbar */
-      "altC":      false, /* focus on the Chat window */
-      "cmdShift2": true, /* shows a gritter popup showing a line author */
-      "delete":    true,
-      "return":    true,
-      "esc":       true, /* in mozilla versions 14-19 avoid reconnecting pad */
-      "cmdS":      true, /* save a revision */
-      "tab":       true, /* indent */
-      "cmdZ":      true, /* undo/redo */
-      "cmdY":      true, /* redo */
-      "cmdI":      true, /* italic */
-      "cmdB":      true, /* bold */
-      "cmdU":      true, /* underline */
-      "cmd5":      true, /* strike through */
-      "cmdShiftL": true, /* unordered list */
-      "cmdShiftN": true, /* ordered list */
-      "cmdShift1": true, /* ordered list */
-      "cmdShiftC": true, /* clear authorship */
-      "cmdH":      true, /* backspace */
-      "ctrlHome":  true, /* scroll to top of pad */
-      "pageUp":    true,
-      "pageDown":  true
-    },
-  
-    /*
-     * Should we suppress errors from being visible in the default Pad Text?
-     */
-    "suppressErrorsInPadText": true,
-  
-    /*
-     * If this option is enabled, a user must have a session to access pads.
-     * This effectively allows only group pads to be accessed.
-     */
-    "requireSession": false,
-  
-    /*
-     * Users may edit pads but not create new ones.
-     *
-     * Pad creation is only via the API.
-     * This applies both to group pads and regular pads.
-     */
-    "editOnly": false,
-  
-    /*
-     * If set to true, those users who have a valid session will automatically be
-     * granted access to password protected pads.
-     */
-    "sessionNoPassword": false,
-  
-    /*
-     * If true, all css & js will be minified before sending to the client.
-     *
-     * This will improve the loading performance massively, but makes it difficult
-     * to debug the javascript/css
-     */
-    "minify": true,
-  
-    /*
-     * How long may clients use served javascript code (in seconds)?
-     *
-     * Not setting this may cause problems during deployment.
-     * Set to 0 to disable caching.
-     */
-    "maxAge": 21600, // 60 * 60 * 6 = 6 hours
-  
-    /*
-     * Absolute path to the Abiword executable.
-     *
-     * Abiword is needed to get advanced import/export features of pads. Setting
-     * it to null disables Abiword and will only allow plain text and HTML
-     * import/exports.
-     */
-    "abiword": null,
-  
-    /*
-     * This is the absolute path to the soffice executable.
-     *
-     * LibreOffice can be used in lieu of Abiword to export pads.
-     * Setting it to null disables LibreOffice exporting.
-     */
-    "soffice": "/etherpad-export.sh",
-  
-    /*
-     * Path to the Tidy executable.
-     *
-     * Tidy is used to improve the quality of exported pads.
-     * Setting it to null disables Tidy.
-     */
-    "tidyHtml": null,
-  
-    /*
-     * Allow import of file types other than the supported ones:
-     * txt, doc, docx, rtf, odt, html & htm
-     */
-    "allowUnknownFileEnds": false,
-  
-    /*
-     * This setting is used if you require authentication of all users.
-     *
-     * Note: "/admin" always requires authentication.
-     */
-    "requireAuthentication": false,
-  
-    /*
-     * Require authorization by a module, or a user with is_admin set, see below.
-     */
-    "requireAuthorization": false,
-  
-    /*
-     * When you use NGINX or another proxy/load-balancer set this to true.
-     *
-     * This is especially necessary when the reverse proxy performs SSL
-     * termination, otherwise the cookies will not have the "secure" flag.
-     *
-     * The other effect will be that the logs will contain the real client's IP,
-     * instead of the reverse proxy's IP.
-     */
-    "trustProxy": true,
+{
+  /*
+   * Name your instance!
+   */
+  "title": "Etherpad",
 
-    /*
-     * Settings controlling the session cookie issued by Etherpad.
-     */
-     "cookie": {
-      /*
-       * Value of the SameSite cookie property. "Lax" is recommended unless
-       * Etherpad will be embedded in an iframe from another site, in which case
-       * this must be set to "None". Note: "None" will not work (the browser will
-       * not send the cookie to Etherpad) unless https is used to access Etherpad
-       * (either directly or via a reverse proxy with "trustProxy" set to true).
-       *
-       * "Strict" is not recommended because it has few security benefits but
-       * significant usability drawbacks vs. "Lax". See
-       * https://stackoverflow.com/q/41841880 for discussion.
-       */
-      "sameSite": "None"
-    },
-    /*
-     * Privacy: disable IP logging
-     */
-    "disableIPlogging": true,
-  
-    /*
-     * Time (in seconds) to automatically reconnect pad when a "Force reconnect"
-     * message is shown to user.
-     *
-     * Set to 0 to disable automatic reconnection.
-     */
-    "automaticReconnectionTimeout": 0,
-  
-    /*
-     * By default, when caret is moved out of viewport, it scrolls the minimum
-     * height needed to make this line visible.
-     */
-    "scrollWhenFocusLineIsOutOfViewport": {
-  
-      /*
-       * Percentage of viewport height to be additionally scrolled.
-       *
-       * E.g.: use "percentage.editionAboveViewport": 0.5, to place caret line in
-       *       the middle of viewport, when user edits a line above of the
-       *       viewport
-       *
-       * Set to 0 to disable extra scrolling
-       */
-      "percentage": {
-        "editionAboveViewport": 0,
-        "editionBelowViewport": 0
-      },
-  
-      /*
-       * Time (in milliseconds) used to animate the scroll transition.
-       * Set to 0 to disable animation
-       */
-      "duration": 0,
-  
-      /*
-       * Flag to control if it should scroll when user places the caret in the
-       * last line of the viewport
-       */
-      "scrollWhenCaretIsInTheLastLineOfViewport": false,
-  
-      /*
-       * Percentage of viewport height to be additionally scrolled when user
-       * presses arrow up in the line of the top of the viewport.
-       *
-       * Set to 0 to let the scroll to be handled as default by Etherpad
-       */
-      "percentageToScrollWhenUserPressesArrowUp": 0
-    },
-  
-    /*
-     * Users for basic authentication.
-     *
-     * is_admin = true gives access to /admin.
-     * If you do not uncomment this, /admin will not be available!
-     *
-     * WARNING: passwords should not be stored in plaintext in this file.
-     *          If you want to mitigate this, please install ep_hash_auth and
-     *          follow the section "secure your installation" in README.md
-     */
-  
-    /*
-    "users": {
-      "admin": {
-        // 1) "password" can be replaced with "hash" if you install ep_hash_auth
-        // 2) please note that if password is null, the user will not be created
-        "password": "changeme1",
-        "is_admin": true
-      },
-      "user": {
-        // 1) "password" can be replaced with "hash" if you install ep_hash_auth
-        // 2) please note that if password is null, the user will not be created
-        "password": "changeme1",
-        "is_admin": false
-      }
-    },
-    */
-  
-    /*
-     * Restrict socket.io transport methods
-     */
-    "socketTransportProtocols" : ["xhr-polling", "jsonp-polling", "htmlfile"],
-  
-    /*
-     * Allow Load Testing tools to hit the Etherpad Instance.
-     *
-     * WARNING: this will disable security on the instance.
-     */
-    "loadTest": false,
-  
-    /*
-     * Disable indentation on new line when previous line ends with some special
-     * chars (':', '[', '(', '{')
-     */
-  
-    /*
-    "indentationOnNewLine": false,
-    */
-  
-    /*
-     * Delete pads plugin configuration.
-     */
-    "ep_pad_ttl": {
-      "ttl": 86400, // 24 hours
-      "timeout": 30,
-      "interval": 21600, // 6 hour
-    },
-  
-    /*
-     * Redis publisher plugin configuration.
-     * npm i git+https://git@github.com/pedrobmarin/ep_redis_publisher.git
-     */
-  
-    "ep_redis_publisher": {
-      "host": "redis",
-      "port": 6379
-    },
-  
-    /*
-    "ep_redis_publisher": {
-      "host": "localhost",
-      "port": 6379,
+  /*
+   * Pathname of the favicon you want to use. If null, the skin's favicon is
+   * used if one is provided by the skin, otherwise the default Etherpad favicon
+   * is used. If this is a relative path it is interpreted as relative to the
+   * Etherpad root directory.
+   */
+  "favicon": null,
+
+  /*
+   * Skin name.
+   *
+   * Its value has to be an existing directory under src/static/skins.
+   * You can write your own, or use one of the included ones:
+   *
+   * - "no-skin":  an empty skin (default). This yields the unmodified,
+   *               traditional Etherpad theme.
+   * - "colibris": the new experimental skin (since Etherpad 1.8), candidate to
+   *               become the default in Etherpad 2.0
+   */
+  "skinName": "bigbluebutton",
+
+  /*
+   * Skin Variants
+   *
+   * Use the UI skin variants builder at /p/test#skinvariantsbuilder
+   *
+   * For the colibris skin only, you can choose how to render the three main
+   * containers:
+   * - toolbar (top menu with icons)
+   * - editor (containing the text of the pad)
+   * - background (area outside of editor, mostly visible when using page style)
+   *
+   * For each of the 3 containers you can choose 4 color combinations:
+   * super-light, light, dark, super-dark.
+   *
+   * For example, to make the toolbar dark, you will include "dark-toolbar" into
+   * skinVariants.
+   *
+   * You can provide multiple skin variants separated by spaces. Default
+   * skinVariant is "super-light-toolbar super-light-editor light-background".
+   *
+   * For the editor container, you can also make it full width by adding
+   * "full-width-editor" variant (by default editor is rendered as a page, with
+   * a max-width of 900px).
+   */
+  "skinVariants": "super-light-toolbar super-light-editor light-background",
+
+  /*
+   * IP and port which Etherpad should bind at.
+   *
+   * Binding to a Unix socket is also supported: just use an empty string for
+   * the ip, and put the full path to the socket in the port parameter.
+   *
+   * EXAMPLE USING UNIX SOCKET:
+   *    "ip": "",                             // <-- has to be an empty string
+   *    "port" : "/somepath/etherpad.socket", // <-- path to a Unix socket
+   */
+  "ip": "0.0.0.0",
+  "port": 9001,
+
+  /*
+   * Option to hide/show the settings.json in admin page.
+   *
+   * Default option is set to true
+   */
+  "showSettingsInAdminPage": true,
+
+  /*
+   * Node native SSL support
+   *
+   * This is disabled by default.
+   * Make sure to have the minimum and correct file access permissions set so
+   * that the Etherpad server can access them
+   */
+
+  /*
+  "ssl" : {
+            "key"  : "/path-to-your/epl-server.key",
+            "cert" : "/path-to-your/epl-server.crt",
+            "ca": ["/path-to-your/epl-intermediate-cert1.crt", "/path-to-your/epl-intermediate-cert2.crt"]
+          },
+  */
+
+  /*
+   * The type of the database.
+   *
+   * You can choose between many DB drivers, for example: dirty, postgres,
+   * sqlite, mysql.
+   *
+   * You shouldn't use "dirty" for for anything else than testing or
+   * development.
+   *
+   *
+   * Database specific settings are dependent on dbType, and go in dbSettings.
+   * Remember that since Etherpad 1.6.0 you can also store this information in
+   * credentials.json.
+   *
+   * For a complete list of the supported drivers, please refer to:
+   * https://www.npmjs.com/package/ueberdb2
+   */
+
+  "dbType": "redis",
+  "dbSettings": {
+    "host": "redis",
+    "port": 6379
+  },
+
+  /*
+   * An Example of MySQL Configuration (commented out).
+   *
+   * See: https://github.com/ether/etherpad-lite/wiki/How-to-use-Etherpad-Lite-with-MySQL
+   */
+
+  /*
+  "dbType" : "redis",
+  "dbSettings" : {
+    "host": "127.0.0.1",
+    "port": 6379,
+    "client_options": {
       "password": "PASSWORD"
-    },
-    */
-  
+    }
+  },
+  */
+
+  /*
+   * The default text of a pad
+   */
+  "defaultPadText" : "",
+
+  /*
+   * Default Pad behavior.
+   *
+   * Change them if you want to override.
+   */
+  "padOptions": {
+    "noColors":         true,
+    "showControls":     true,
+    "showChat":         false,
+    "showLineNumbers":  false,
+    "useMonospaceFont": false,
+    "userName":         false,
+    "userColor":        false,
+    "rtl":              false,
+    "alwaysShowChat":   false,
+    "chatAndUsers":     false,
+    "lang":             "en"
+  },
+
+  /*
+   * Pad Shortcut Keys
+   */
+  "padShortcutEnabled" : {
+    "altF9":     true, /* focus on the File Menu and/or editbar */
+    "altC":      false, /* focus on the Chat window */
+    "cmdShift2": true, /* shows a gritter popup showing a line author */
+    "delete":    true,
+    "return":    true,
+    "esc":       true, /* in mozilla versions 14-19 avoid reconnecting pad */
+    "cmdS":      true, /* save a revision */
+    "tab":       true, /* indent */
+    "cmdZ":      true, /* undo/redo */
+    "cmdY":      true, /* redo */
+    "cmdI":      true, /* italic */
+    "cmdB":      true, /* bold */
+    "cmdU":      true, /* underline */
+    "cmd5":      true, /* strike through */
+    "cmdShiftL": true, /* unordered list */
+    "cmdShiftN": true, /* ordered list */
+    "cmdShift1": true, /* ordered list */
+    "cmdShiftC": true, /* clear authorship */
+    "cmdH":      true, /* backspace */
+    "ctrlHome":  true, /* scroll to top of pad */
+    "pageUp":    true,
+    "pageDown":  true
+  },
+
+  /*
+   * Should we suppress errors from being visible in the default Pad Text?
+   */
+  "suppressErrorsInPadText": true,
+
+  /*
+   * If this option is enabled, a user must have a session to access pads.
+   * This effectively allows only group pads to be accessed.
+   */
+  "requireSession": false,
+
+  /*
+   * Users may edit pads but not create new ones.
+   *
+   * Pad creation is only via the API.
+   * This applies both to group pads and regular pads.
+   */
+  "editOnly": false,
+
+  /*
+   * If true, all css & js will be minified before sending to the client.
+   *
+   * This will improve the loading performance massively, but makes it difficult
+   * to debug the javascript/css
+   */
+  "minify": true,
+
+  /*
+   * How long may clients use served javascript code (in seconds)?
+   *
+   * Not setting this may cause problems during deployment.
+   * Set to 0 to disable caching.
+   */
+  "maxAge": 21600, // 60 * 60 * 6 = 6 hours
+
+  /*
+   * Absolute path to the Abiword executable.
+   *
+   * Abiword is needed to get advanced import/export features of pads. Setting
+   * it to null disables Abiword and will only allow plain text and HTML
+   * import/exports.
+   */
+  "abiword": null,
+
+  /*
+   * This is the absolute path to the soffice executable.
+   *
+   * LibreOffice can be used in lieu of Abiword to export pads.
+   * Setting it to null disables LibreOffice exporting.
+   */
+  "soffice": "/etherpad-export.sh",
+
+  /*
+   * Path to the Tidy executable.
+   *
+   * Tidy is used to improve the quality of exported pads.
+   * Setting it to null disables Tidy.
+   */
+  "tidyHtml": null,
+
+  /*
+   * Allow import of file types other than the supported ones:
+   * txt, doc, docx, rtf, odt, html & htm
+   */
+  "allowUnknownFileEnds": false,
+
+  /*
+   * This setting is used if you require authentication of all users.
+   *
+   * Note: "/admin" always requires authentication.
+   */
+  "requireAuthentication": false,
+
+  /*
+   * Require authorization by a module, or a user with is_admin set, see below.
+   */
+  "requireAuthorization": false,
+
+  /*
+   * When you use NGINX or another proxy/load-balancer set this to true.
+   *
+   * This is especially necessary when the reverse proxy performs SSL
+   * termination, otherwise the cookies will not have the "secure" flag.
+   *
+   * The other effect will be that the logs will contain the real client's IP,
+   * instead of the reverse proxy's IP.
+   */
+  "trustProxy": true,
+
+  /*
+   * Settings controlling the session cookie issued by Etherpad.
+   */
+  "cookie": {
+    /*
+     * Value of the SameSite cookie property. "Lax" is recommended unless
+     * Etherpad will be embedded in an iframe from another site, in which case
+     * this must be set to "None". Note: "None" will not work (the browser will
+     * not send the cookie to Etherpad) unless https is used to access Etherpad
+     * (either directly or via a reverse proxy with "trustProxy" set to true).
+     *
+     * "Strict" is not recommended because it has few security benefits but
+     * significant usability drawbacks vs. "Lax". See
+     * https://stackoverflow.com/q/41841880 for discussion.
+     */
+    "sameSite": "None"
+  },
+
+  /*
+   * Privacy: disable IP logging
+   */
+  "disableIPlogging": true,
+
+  /*
+   * Time (in seconds) to automatically reconnect pad when a "Force reconnect"
+   * message is shown to user.
+   *
+   * Set to 0 to disable automatic reconnection.
+   */
+  "automaticReconnectionTimeout": 0,
+
+  /*
+   * By default, when caret is moved out of viewport, it scrolls the minimum
+   * height needed to make this line visible.
+   */
+  "scrollWhenFocusLineIsOutOfViewport": {
 
     /*
-      * From Etherpad 1.9.0 onwards, when Etherpad is in production mode commits from individual users are rate limited
-      *
-      * The default is to allow at most 10 changes per IP in a 1 second window.
-      * After that the change is rejected.
-      *
-      * See https://github.com/animir/node-rate-limiter-flexible/wiki/Overall-example#websocket-single-connection-prevent-flooding for more options
-      */
-    "commitRateLimiting": {
-      // duration of the rate limit window (seconds)
-      "duration": 1,
-  
-      // maximum number of chanes per IP to allow during the rate limit window
-      "points": 100
+     * Percentage of viewport height to be additionally scrolled.
+     *
+     * E.g.: use "percentage.editionAboveViewport": 0.5, to place caret line in
+     *       the middle of viewport, when user edits a line above of the
+     *       viewport
+     *
+     * Set to 0 to disable extra scrolling
+     */
+    "percentage": {
+      "editionAboveViewport": 0,
+      "editionBelowViewport": 0
     },
-  
-    
+
     /*
-     * Toolbar buttons configuration.
-     *
-     * Uncomment to customize.
+     * Time (in milliseconds) used to animate the scroll transition.
+     * Set to 0 to disable animation
      */
-  
-    "toolbar": {
-      "left": [
-        ["bold", "italic", "underline", "strikethrough"],
-        ["orderedlist", "unorderedlist", "undo", "redo"]
-      ],
-      "right": [["importexport"]]
+    "duration": 0,
+
+    /*
+     * Flag to control if it should scroll when user places the caret in the
+     * last line of the viewport
+     */
+    "scrollWhenCaretIsInTheLastLineOfViewport": false,
+
+    /*
+     * Percentage of viewport height to be additionally scrolled when user
+     * presses arrow up in the line of the top of the viewport.
+     *
+     * Set to 0 to let the scroll to be handled as default by Etherpad
+     */
+    "percentageToScrollWhenUserPressesArrowUp": 0
+  },
+
+  /*
+   * User accounts. These accounts are used by:
+   *   - default HTTP basic authentication if no plugin handles authentication
+   *   - some but not all authentication plugins
+   *   - some but not all authorization plugins
+   *
+   * User properties:
+   *   - password: The user's password. Some authentication plugins will ignore
+   *     this.
+   *   - is_admin: true gives access to /admin. Defaults to false. If you do not
+   *     uncomment this, /admin will not be available!
+   *   - readOnly: If true, this user will not be able to create new pads or
+   *     modify existing pads. Defaults to false.
+   *   - canCreate: If this is true and readOnly is false, this user can create
+   *     new pads. Defaults to true.
+   *
+   * Authentication and authorization plugins may define additional properties.
+   *
+   * WARNING: passwords should not be stored in plaintext in this file.
+   *          If you want to mitigate this, please install ep_hash_auth and
+   *          follow the section "secure your installation" in README.md
+   */
+
+  /*
+  "users": {
+    "admin": {
+      // 1) "password" can be replaced with "hash" if you install ep_hash_auth
+      // 2) please note that if password is null, the user will not be created
+      "password": "changeme1",
+      "is_admin": true
     },
-  
+    "user": {
+      // 1) "password" can be replaced with "hash" if you install ep_hash_auth
+      // 2) please note that if password is null, the user will not be created
+      "password": "changeme1",
+      "is_admin": false
+    }
+  },
+  */
+
+  /*
+   * Restrict socket.io transport methods
+   */
+  "socketTransportProtocols" : ["xhr-polling", "jsonp-polling", "htmlfile"],
+
+  "socketIo": {
     /*
-     * Expose Etherpad version in the web interface and in the Server http header.
-     *
-     * Do not enable on production machines.
+     * Maximum permitted client message size (in bytes). All messages from
+     * clients that are larger than this will be rejected. Large values make it
+     * possible to paste large amounts of text, and plugins may require a larger
+     * value to work properly, but increasing the value increases susceptibility
+     * to denial of service attacks (malicious clients can exhaust memory).
      */
-    "exposeVersion": false,
-  
-    /*
-     * The log level we are using.
-     *
-     * Valid values: DEBUG, INFO, WARN, ERROR
-     */
-    "loglevel": "INFO",
-  
-    /*
-     * Logging configuration. See log4js documentation for further information:
-     * https://github.com/nomiddlename/log4js-node
-     *
-     * You can add as many appenders as you want here.
-     */
-    "logconfig" :
-      { "appenders": [
-          { "type": "console"
-          //, "category": "access"// only logs pad access
-          }
-  
-        /*
-        , { "type": "file"
-        , "filename": "your-log-file-here.log"
-        , "maxLogSize": 1024
-        , "backups": 3 // how many log files there're gonna be at max
-        //, "category": "test" // only log a specific category
-          }
-        */
-  
-        /*
-        , { "type": "logLevelFilter"
-          , "level": "warn" // filters out all log messages that have a lower level than "error"
-          , "appender":
-            {  Use whatever appender you want here  }
-          }
-        */
-  
-        /*
-        , { "type": "logLevelFilter"
-          , "level": "error" // filters out all log messages that have a lower level than "error"
-          , "appender":
-            { "type": "smtp"
-            , "subject": "An error occurred in your EPL instance!"
-            , "recipients": "bar@blurdybloop.com, baz@blurdybloop.com"
-            , "sendInterval": 300 // 60 * 5 = 5 minutes -- will buffer log messages; set to 0 to send a mail for every message
-            , "transport": "SMTP", "SMTP": { // see https://github.com/andris9/Nodemailer#possible-transport-methods
-                "host": "smtp.example.com", "port": 465,
-                "secureConnection": true,
-                "auth": {
-                    "user": "foo@example.com",
-                    "pass": "bar_foo"
-                }
-              }
-            }
-          }
-        */
-  
-        ]
-      }, // logconfig
-      /* Override any strings found in locale directories */
-    "customLocaleStrings": {}
-  }
-  
+    "maxHttpBufferSize": 10000
+  },
+
+  /*
+   * Allow Load Testing tools to hit the Etherpad Instance.
+   *
+   * WARNING: this will disable security on the instance.
+   */
+  "loadTest": false,
+
+  /**
+  * Disable dump of objects preventing a clean exit
+  */
+  "dumpOnUncleanExit": false,
+
+  /*
+   * Disable indentation on new line when previous line ends with some special
+   * chars (':', '[', '(', '{')
+   */
+
+  /*
+  "indentationOnNewLine": false,
+  */
+
+  "ep_pad_ttl": {
+    "ttl": 86400, // 24 hours
+    "timeout": 30,
+    "interval": 21600 // 6 hours
+  },
+
+  /*
+   * Redis publisher plugin configuration.
+   * npm i git+https://git@github.com/mconf/ep_redis_publisher.git
+   */
+
+  "ep_redis_publisher": {
+    "host": "redis",
+    "port": 6379
+  },
+
+  /*
+   * From Etherpad 1.8.3 onwards, import and export of pads is always rate
+   * limited.
+   *
+   * The default is to allow at most 10 requests per IP in a 90 seconds window.
+   * After that the import/export request is rejected.
+   *
+   * See https://github.com/nfriedly/express-rate-limit for more options
+   */
+  "importExportRateLimiting": {
+    // duration of the rate limit window (milliseconds)
+    "windowMs": 90000,
+
+    // maximum number of requests per IP to allow during the rate limit window
+    "max": 10
+  },
+
+  /*
+   * From Etherpad 1.8.3 onwards, the maximum allowed size for a single imported
+   * file is always bounded.
+   *
+   * File size is specified in bytes. Default is 50 MB.
+   */
+  "importMaxFileSize": 52428800, // 50 * 1024 * 1024
+
+  /*
+   * From Etherpad 1.8.5 onwards, when Etherpad is in production mode commits from individual users are rate limited
+   *
+   * The default is to allow at most 10 changes per IP in a 1 second window.
+   * After that the change is rejected.
+   *
+   * See https://github.com/animir/node-rate-limiter-flexible/wiki/Overall-example#websocket-single-connection-prevent-flooding for more options
+   */
+  "commitRateLimiting": {
+    // duration of the rate limit window (seconds)
+    "duration": 1,
+
+    // maximum number of changes per IP to allow during the rate limit window
+    "points": 100
+  },
+
+
+  /*
+   * Toolbar buttons configuration.
+   *
+   * Uncomment to customize.
+   */
+
+  "toolbar": {
+    "left": [
+      ["bold", "italic", "underline", "strikethrough"],
+      ["orderedlist", "unorderedlist", "undo", "redo"]
+    ],
+    "right": [["importexport"]]
+  },
+
+  /*
+   * Expose Etherpad version in the web interface and in the Server http header.
+   *
+   * Do not enable on production machines.
+   */
+  "exposeVersion": false,
+
+  /*
+   * The log level we are using.
+   *
+   * Valid values: DEBUG, INFO, WARN, ERROR
+   */
+  "loglevel": "INFO",
+
+  /* Override any strings found in locale directories */
+  "customLocaleStrings": {},
+
+  /* Disable Admin UI tests */
+  "enableAdminUITests": false
+}
+
+
+


### PR DESCRIPTION
Following https://github.com/bigbluebutton/bigbluebutton/pull/14550 .

Also updated the settings.json file with https://github.com/ether/etherpad-lite/blob/1.8.17/settings.json.template .

Made sure to preserve BigBlueButton's common settings and a couple of extras
that I imagined to make sense for the docker environment:

 - ip: `0.0.0.0`
	BigBlueButton uses `127.0.0.1`
```
  /*
   * IP and port which Etherpad should bind at.
   *
   * Binding to a Unix socket is also supported: just use an empty string for
   * the ip, and put the full path to the socket in the port parameter.
   *
   * EXAMPLE USING UNIX SOCKET:
   *    "ip": "",                             // <-- has to be an empty string
   *    "port" : "/somepath/etherpad.socket", // <-- path to a Unix socket
   */
  "ip": "0.0.0.0",
  "port": 9001,
```
 - host: `redis`
	BigBlueButton uses `127.0.0.1`
```
  /*
   * The type of the database.
   *
   * You can choose between many DB drivers, for example: dirty, postgres,
   * sqlite, mysql.
   *
   * You shouldn't use "dirty" for for anything else than testing or
   * development.
   *
   *
   * Database specific settings are dependent on dbType, and go in dbSettings.
   * Remember that since Etherpad 1.6.0 you can also store this information in
   * credentials.json.
   *
   * For a complete list of the supported drivers, please refer to:
   * https://www.npmjs.com/package/ueberdb2
   */

  "dbType": "redis",
  "dbSettings": {
    "host": "redis",
    "port": 6379
  },
```
 - soffice: `/etherpad-export.sh`
	BigBlueButton uses `/usr/share/bbb-libreoffice-conversion/etherpad-export.sh`
```
  /*
   * This is the absolute path to the soffice executable.
   *
   * LibreOffice can be used in lieu of Abiword to export pads.
   * Setting it to null disables LibreOffice exporting.
   */
  "soffice": "/etherpad-export.sh",
```
 - disableIPlogging: `true`
	BigBlueButton uses `false` (Etherpad's default)
```
  /*
   * Privacy: disable IP logging
   */
  "disableIPlogging": true,
```
 - host: `redis`
	BigBlueButton uses `127.0.0.1`
```
  /*
   * Redis publisher plugin configuration.
   * npm i git+https://git@github.com/mconf/ep_redis_publisher.git
   */

  "ep_redis_publisher": {
    "host": "redis",
    "port": 6379
  },
```

Needs to be tested :)