### PR TITLE
etherpad: avoid icons overlapping

### DIFF
--- a/mod/etherpad/settings.json
+++ b/mod/etherpad/settings.json
@@ -576,9 +576,10 @@
   "toolbar": {
     "left": [
       ["bold", "italic", "underline", "strikethrough"],
-      ["orderedlist", "unorderedlist", "undo", "redo"]
+      ["orderedlist", "unorderedlist", "undo", "redo"],
+      ["importexport"]
     ],
-    "right": [["importexport"]]
+    "right": [[]]
   },
 
   /*


### PR DESCRIPTION
cc @frankemax

Reference: https://github.com/bigbluebutton/bigbluebutton/pull/14567