### PR TITLE
etherpad: enforce bbb-pads session handling

### DIFF
--- a/mod/etherpad/settings.json
+++ b/mod/etherpad/settings.json
@@ -280,7 +280,7 @@
    * If this option is enabled, a user must have a session to access pads.
    * This effectively allows only group pads to be accessed.
    */
-  "requireSession": false,
+  "requireSession": true,
 
   /*
    * Users may edit pads but not create new ones.
@@ -288,7 +288,7 @@
    * Pad creation is only via the API.
    * This applies both to group pads and regular pads.
    */
-  "editOnly": false,
+  "editOnly": true,
 
   /*
    * If true, all css & js will be minified before sending to the client.


### PR DESCRIPTION
At v2.5 we intoduced `bbb-pads` as a session manager for Etherpad.

Enabling `requireSession` and `editOnly` at Etherpad's settings closes
the HTTP access from all other sources besides `bbb-pads`.