### PR TITLE
Set executable Permissions for Entrypoint.sh

### DIFF
--- a/mod/bbb-pads/Dockerfile
+++ b/mod/bbb-pads/Dockerfile
@@ -13,6 +13,7 @@ RUN apt update && apt install -y jq moreutils \
     && useradd --uid 2003 --user-group bbb-pads
 
 COPY --from=builder /bbb-pads /bbb-pads
-USER bbb-pads
 COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+USER bbb-pads
 ENTRYPOINT /entrypoint.sh


### PR DESCRIPTION
The entrypoint file was not in the executable trace after it was copied. Necessary adjustments have been made.