### PR TITLE
Entrypoint File Not Executable Permissions

### DIFF
--- a/mod/apps-akka/Dockerfile
+++ b/mod/apps-akka/Dockerfile
@@ -28,6 +28,7 @@ FROM alangecker/bbb-docker-base-java
 COPY --from=builder /bbb-apps-akka-0.0.4 /bbb-apps-akka
 COPY bbb-apps-akka.conf /etc/bigbluebutton/bbb-apps-akka.conf.tmpl
 COPY logback.xml /bbb-apps-akka/conf/logback.xml
+RUN  chmod +x /entrypoint.sh
 COPY entrypoint.sh /entrypoint.sh
 
 USER bigbluebutton


### PR DESCRIPTION
The entry point file was not in the executable trace after it was copied. Necessary adjustments have been made.