### PR TITLE
Entrypoint file Permissions Error

### DIFF
--- a/mod/fsesl-akka/Dockerfile
+++ b/mod/fsesl-akka/Dockerfile
@@ -32,6 +32,7 @@ FROM alangecker/bbb-docker-base-java
 COPY --from=builder /bbb-fsesl-akka-0.0.2 /bbb-fsesl-akka
 COPY bbb-fsesl-akka.conf /etc/bigbluebutton/bbb-fsesl-akka.conf.tmpl
 COPY logback.xml /bbb-fsesl-akka/conf/logback.xml
+RUN chmod +x /entrypoint.sh
 COPY entrypoint.sh /entrypoint.sh
 
 USER bigbluebutton


### PR DESCRIPTION
The entry point file was not in the executable trace after it was copied. Necessary adjustments have been made.