### PR TITLE
coturn Entrypoint Path Error

### DIFF
--- a/docker-compose.tmpl.yml
+++ b/docker-compose.tmpl.yml
@@ -400,7 +400,7 @@ services:
       - ${COTURN_TLS_CERT_PATH}:/tmp/cert.pem
       - ${COTURN_TLS_KEY_PATH}:/tmp/key.pem
       {{end}}
-      - ./mod/coturn/entrypoint.sh:/usr/local/bin/docker-entrypoint.sh
+      - ./mod/coturn/entrypoint.sh:/docker-entrypoint.sh
       - ./mod/coturn/turnserver.conf:/etc/coturn/turnserver.conf
     environment:
       ENABLE_HTTPS_PROXY:


### PR DESCRIPTION
It was giving OCI Runtime error. The path to the docker-entrypoint file is incorrectly specified.