### PR TITLE
Set client_max_body_size for greenlight

### DIFF
--- a/mod/nginx/bbb/greenlight.nginx
+++ b/mod/nginx/bbb/greenlight.nginx
@@ -5,27 +5,28 @@
 
 
 location /b {
-  proxy_pass          http://host.docker.internal:5000;
-  proxy_set_header    Host              $host;
-  proxy_set_header    X-Forwarded-For   $proxy_add_x_forwarded_for;
-  proxy_set_header    X-Forwarded-Proto $scheme;
-  proxy_set_header    X-Forwarded-Ssl on;
-  proxy_http_version  1.1;
+  proxy_pass           http://host.docker.internal:5000;
+  proxy_set_header     Host              $host;
+  proxy_set_header     X-Forwarded-For   $proxy_add_x_forwarded_for;
+  proxy_set_header     X-Forwarded-Proto $scheme;
+  proxy_set_header     X-Forwarded-Ssl on;
+  proxy_http_version   1.1;
+  client_max_body_size 1000m;
 }
 
 location /b/cable {
-  proxy_pass          http://host.docker.internal:5000;
-  proxy_set_header    Host              $host;
-  proxy_set_header    X-Forwarded-For   $proxy_add_x_forwarded_for;
-  proxy_set_header    X-Forwarded-Proto $scheme;
-  proxy_set_header    X-Forwarded-Ssl on;
-  proxy_set_header    Upgrade           $http_upgrade;
-  proxy_set_header    Connection        "Upgrade";
-  proxy_http_version  1.1;
-  proxy_read_timeout  6h;
-  proxy_send_timeout  6h;
-  client_body_timeout 6h;
-  send_timeout        6h;
+  proxy_pass           http://host.docker.internal:5000;
+  proxy_set_header     Host              $host;
+  proxy_set_header     X-Forwarded-For   $proxy_add_x_forwarded_for;
+  proxy_set_header     X-Forwarded-Proto $scheme;
+  proxy_set_header     X-Forwarded-Ssl on;
+  proxy_set_header     Upgrade           $http_upgrade;
+  proxy_set_header     Connection        "Upgrade";
+  proxy_http_version   1.1;
+  proxy_read_timeout   6h;
+  proxy_send_timeout   6h;
+  client_body_timeout  6h;
+  send_timeout         6h;
 }
 
 # this is necessary for the preupload_presentation feature


### PR DESCRIPTION
As greenlight also allows presentation upload beforehands, right now presentations with size of >2MB would end up in a 413 - Request entity too large error. I would suggest to add here the same limit as in bbb-web for presentation upload.