### PR TITLE
Fix learning-dashboard (alias)

### DIFF
--- a/mod/nginx/bbb/learning-dashboard.nginx
+++ b/mod/nginx/bbb/learning-dashboard.nginx
@@ -1,5 +1,5 @@
 location ~ /learning-analytics-dashboard/([0-9a-f]+-[0-9]+)/(.*) {
-    root /var/bigbluebutton/learning-analytics-dashboard/;
+    alias /var/bigbluebutton/learning-dashboard/$1/$2;
     autoindex off;
 }
 


### PR DESCRIPTION
This is the same as #200 but using nginx alias rather than having to create a symlink.