### PR TITLE
fixed a dependency issue which led to an error during build

### DIFF
--- a/mod/recordings/Dockerfile
+++ b/mod/recordings/Dockerfile
@@ -78,7 +78,7 @@ COPY --from=presentation /scripts /usr/local/bigbluebutton/core/scripts/
 # install ruby dependencies
 RUN cd /usr/local/bigbluebutton/core \
     && gem install builder \
-    && gem install bundler --no-document \
+    && gem install bundler -v 2.4.22 --no-document \
     && bundle config set --local deployment true \
     && bundle install \
     && bundle clean \


### PR DESCRIPTION
There was an error message regarding the wrong version of a ruby component, when doing `docker compose build`. This pull request specifies the suggested version of that dependency.

![image](https://github.com/user-attachments/assets/0845b672-781d-4cbe-a098-633e5a213f83)
