### PR TITLE
update bbb-build container tag

### DIFF
--- a/scripts/generate-compose
+++ b/scripts/generate-compose
@@ -36,7 +36,7 @@ function get_tag {
 }
 
 # https://hub.docker.com/r/bigbluebutton/bbb-build
-BBB_BUILD_TAG=v3.0.x-release--2025-02-06-143818
+BBB_BUILD_TAG=v3.0.x-release--2025-03-12-163403
 
 docker run  \
     --rm  \

--- a/scripts/generate-compose
+++ b/scripts/generate-compose
@@ -36,7 +36,7 @@ function get_tag {
 }
 
 # https://hub.docker.com/r/bigbluebutton/bbb-build
-BBB_BUILD_TAG=v3.0.x-release--2025-03-12-163403
+BBB_BUILD_TAG=v3.0.x-release
 
 docker run  \
     --rm  \


### PR DESCRIPTION
Was updated to [v3.0.x-release--2025-03-12-163403](https://hub.docker.com/r/bigbluebutton/bbb-build/tags)