### PR TITLE
Add missing volume mounts for coturn and redis

### DIFF
--- a/docker-compose.tmpl.yml
+++ b/docker-compose.tmpl.yml
@@ -207,6 +207,8 @@ services:
     networks:
       bbb-net:
         ipv4_address: 10.7.7.5
+    volumes:
+      - ./data/redis:/data
 
   webrtc-sfu:
     build: 
@@ -495,6 +497,7 @@ services:
       - "--relay-ip=${EXTERNAL_IPv6:-::1}"
     volumes:
       - ./mod/coturn/turnserver.conf:/etc/coturn/turnserver.conf
+      - ./data/coturn:/var/lib/coturn
     network_mode: host
 
 


### PR DESCRIPTION
These directories were marked as volumes in their dockerfile, but nothing was explicitly mounted on them. This makes docker create an unnamed volume and mount that when the container is created, which means that on every down/up cycle, it would leave two unnamed volumes lingering around.

Explicitly mounting these data directories prevents this.