### PR TITLE
Add --listening-ip to coturn command

### DIFF
--- a/docker-compose.tmpl.yml
+++ b/docker-compose.tmpl.yml
@@ -493,6 +493,8 @@ services:
       - "--allowed-peer-ip=${EXTERNAL_IPv4}"
       - "--relay-ip=${EXTERNAL_IPv4}"
       - "--relay-ip=${EXTERNAL_IPv6:-::1}"
+      - "--listening-ip=${TURN_LISTENING_IPv4:-${EXTERNAL_IPv4}}"
+      - "--listening-ip=${TURN_LISTENING_IPv6:-${EXTERNAL_IPv6:-::1}}"
     volumes:
       - ./mod/coturn/turnserver.conf:/etc/coturn/turnserver.conf
     network_mode: host

--- a/sample.env
+++ b/sample.env
@@ -63,6 +63,11 @@ STUN_PORT=3478
 # uncomment and adjust following two lines to add an external TURN server
 #TURN_EXT_SERVER=turns:example.org:443?transport=tcp
 #TURN_EXT_SECRET=
+# uncomment and adjust following two lines to specify the addreess the TURN
+# server should listen on, if it is different to the EXTERNAL_IPvx values, for
+# example when the server is behind a NAT.
+#TURN_LISTENING_IPv4=
+#TURN_LISTENING_IPv6=
 
 # Allowed SIP IPs
 # due to high traffic caused by bots, by default the SIP port is blocked.


### PR DESCRIPTION
This ensures that coturn only listens on our external IP addresses, instead of listening on all interfaces, including internal docker-only interfaces. This prevents issues on some setups, where binding errors are produced, e.g.:

	coturn-1                  | bind: Address not available
	coturn-1                  | bind: Address not available
	coturn-1                  | Cannot bind local socket to addr: Address not available
	coturn-1                  | bind: Address not available
	coturn-1                  | Cannot bind local socket to addr: Address not available
	coturn-1                  | Cannot bind local socket to addr: Address not available
	coturn-1                  | bind: Address not available
	coturn-1                  | Cannot bind local socket to addr: Address not available
	coturn-1                  | bind: Address not available
	coturn-1                  | Cannot bind local socket to addr: Address not available
	coturn-1                  | 0: (14): INFO: Trying to bind TLS/TCP listener socket to addr [fd00:dead:beef::1]:3478, again...
	coturn-1                  | 0: (1): WARNING: Cannot bind DTLS/UDP listener socket to addr [fd00:dead:beef::1]:3478
	coturn-1                  | 0: (1): INFO: Trying to bind DTLS/UDP listener socket to addr [fd00:dead:beef::1]:3478, again...
	coturn-1                  | 0: (15): INFO: Trying to bind TLS/TCP listener socket to addr [fd00:dead:beef::1]:3478, again...
	coturn-1                  | 0: (17): WARNING: Trying to bind fd 99 to <[fd00:dead:beef::1]:3478>: errno=99
	coturn-1                  | 0: (17): WARNING: Cannot bind TLS/TCP listener socket to addr [fd00:dead:beef::1]:3478
	coturn-1                  | 0: (17): INFO: Trying to bind TLS/TCP listener socket to addr [fd00:dead:beef::1]:3478, again...
	coturn-1                  | 0: (16): WARNING: Trying to bind fd 153 to <[fd00:dead:beef::1]:3478>: errno=99
	coturn-1                  | 0: (16): WARNING: Cannot bind TLS/TCP listener socket to addr [fd00:dead:beef::1]:3478
	coturn-1                  | 0: (16): INFO: Trying to bind TLS/TCP listener socket to addr [fd00:dead:beef::1]:3478, again...
	coturn-1                  | 0: (14): WARNING: Trying to bind fd 124 to <[fd00:dead:beef::1]:3478>: errno=99
	coturn-1                  | 0: (15): WARNING: Trying to bind fd 115 to <[fd00:dead:beef::1]:3478>: errno=99

Using the external address as the listening address should work in most setups. For servers behind a NAT, this will fail to start coturn, since the external address is not available. To support those usecases, two new variables (TURN_LISTENING_ADDRESS_IPv4 and
TURN_LISTENING_ADDRESS_IPv6) were added that can be set to override the listening address.