### PR TITLE
Override healthcheck for graphql

### DIFF
--- a/docker-compose.tmpl.yml
+++ b/docker-compose.tmpl.yml
@@ -323,6 +323,12 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: ${POSTGRESQL_SECRET:-password}
       HASURA_GRAPHQL_ADMIN_SECRET: TODO_CHANGE_ME
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8085/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
     networks:
       bbb-net:
         ipv4_address: 10.7.7.31


### PR DESCRIPTION
Implements the solution proposed by @ben-ba to fix #367: failing graphql-server healthcheck

Disclaimer: I'm not an expert on this topic. I was trying BBB for the first time, and noticed this issue.

Before: the container shows unhealthy:

```
$ docker ps                                                                                                                                                                                                                                                   
CONTAINER ID   IMAGE                                                    COMMAND                  CREATED          STATUS                      PORTS  NAMES
[...]
d0d07eea3024   alangecker/bbb-docker-graphql-server:v3.0.19             "/entrypoint.sh /app…"   17 minutes ago   Up 17 minutes (unhealthy)       bbb-docker-bbb-graphql-server-1         
```

After: shows healthy:

```
$ docker ps
CONTAINER ID   IMAGE                                                    COMMAND                  CREATED          STATUS                   PORTS   NAMES
[...]
9e301b6e8f43   alangecker/bbb-docker-graphql-server:v3.0.19             "/entrypoint.sh /app…"   2 minutes ago    Up 2 minutes (healthy)    graphql-server-1
```