### PR TITLE
Correctly check the ENABLE_HTTPS_PROXY variable

### DIFF
--- a/scripts/generate-compose
+++ b/scripts/generate-compose
@@ -18,7 +18,7 @@ if [ -z "$EXTERNAL_IPv4" ]; then
     exit 1
 fi
 
-if [ "$ENABLE_HTTPS_PROXY" ] && [ -z "$LETSENCRYPT_EMAIL" ] && [ -z "$DEV_MODE" ]; then
+if [ "${ENABLE_HTTPS_PROXY:-false}" != "false" ] && [ -z "$LETSENCRYPT_EMAIL" ] && [ -z "$DEV_MODE" ]; then
     echo "ERROR: LETSENCRYPT_EMAIL is not set in .env"
     echo "you need to specify an email adress, otherwise the certificate"
     echo "retrieval will fail"


### PR DESCRIPTION
Correctly check the ENABLE_HTTPS_PROXY variable to avoid setting the variable to false triggering an error about a missing LETSENCRYPT_EMAIL. This reuses the default variable expansion used later in the docker command to determine the actual value and check that it's not the default value of false.